### PR TITLE
ci(workflow):update-closed-issues

### DIFF
--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,0 +1,23 @@
+name: Test Issue Close Trigger
+permissions:
+  contents: read
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print closed issue info
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          echo "Issue Number: $ISSUE_NUMBER"
+          # Prevent workflow command injection from untrusted issue titles
+          TOKEN=$(uuidgen)
+          echo "::stop-commands::${TOKEN}"
+          echo "Title: $ISSUE_TITLE"
+          echo "::${TOKEN}::"
+          echo "Workflow triggered successfully when issue was closed."

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,0 +1,39 @@
+name: Set Project Closed Date
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: read
+
+env:
+  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
+  CLOSED_DATE_FIELD: "Closed Date"
+
+jobs:
+  set-date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve closed date
+        id: when
+        shell: bash
+        run: |
+          ts='${{ github.event.issue.closed_at }}'
+          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
+            echo "Error: closed_at timestamp is missing or null. Refusing to set an incorrect closed date." >&2
+            exit 1
+          fi
+          d=$(date -u -d "$ts" +%F)
+          echo "date=$d" >> "$GITHUB_OUTPUT"
+          echo "Closed date -> $d"
+
+      # Update the "Closed Date" field on that project item
+      - name: Update Closed Date field
+        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ secrets.ORG_PROJECT_PAT }}
+          field-name: ${{ env.CLOSED_DATE_FIELD }}
+          field-value: ${{ steps.when.outputs.date }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automates setting a “Closed Date” on the org project when GitHub issues are closed, and adds a small test workflow to confirm the close trigger works. This removes manual updates and keeps project data accurate.

- **New Features**
  - Adds Set Project Closed Date workflow: on issue close, resolves `closed_at`, formats to UTC `YYYY-MM-DD`, and updates the “Closed Date” field on `https://github.com/orgs/blinklabs-io/projects/11` using `nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b` (pinned).
  - Adds Test Issue Close Trigger workflow: prints issue number and title with command-injection safeguards.

- **Migration**
  - Add `ORG_PROJECT_PAT` repo secret with access to the org Project v2 and permission to update items/fields.
  - Ensure the project has a “Closed Date” date field and that issues are added to the project.
  - Update `PROJECT_URL` if using a different project.

<sup>Written for commit 0638dfd64bec1bc00a4ab2880e4c495164ebb39e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow to validate issue closure events with built-in security measures to prevent potential injection attacks in event data.
  * Added GitHub Actions workflow to automatically update project tracking fields with the date when issues are closed, using secure authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->